### PR TITLE
Fix Headers error by returning to v0.4's elb.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ parameters:
     CloudFrontCert: "0000000-0000-0000-0000-000000000"
 
 extensions:
-- url: https://github.com/stelligent/mu-cloudfront/archive/v0.5.zip
+- url: https://github.com/stelligent/mu-cloudfront/archive/v0.6.zip
 ```
 
 

--- a/elb.yml
+++ b/elb.yml
@@ -74,6 +74,8 @@ Resources:
               QueryString: true
               Cookies:
                 Forward: all
+              Headers: 
+                - '*'
             MaxTTL: 60
             MinTTL: 0
             PathPattern:
@@ -92,8 +94,6 @@ Resources:
           DefaultTTL: 0
           ForwardedValues:
             QueryString: no
-            Headers: 
-              - '*'
             Cookies:
               Forward: all
           MaxTTL: 60

--- a/mu-extension.yml
+++ b/mu-extension.yml
@@ -1,2 +1,2 @@
 name: mu-cloudfront
-version: '0.5'
+version: '0.6'


### PR DESCRIPTION
Going from v0.4 to v0.5 caused failures during creating cloudfront distribution (error being "CREATE_FAILED Your request contains forwarded Header Name * that is not allowed by S3").  Going back fixed those errors.  I've upped the version number to v0.6 now -- not sure if that is what is done.  Hope this helps.