### PR TITLE
added text and AWS doc-link to explain why us-east-1 is hardcoded in elb.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mu-cloudfront
 Extension to create a CloudFront distribution in front of the ALB for a mu environment.  Additionally, this will create an S3 bucket for static resources.
 
-Sample usage: 
+Sample usage:
 
 ```
 ## Specify the id of an ACM cert for CloudFront to use (must be in us-east-1)
@@ -12,6 +12,10 @@ parameters:
 extensions:
 - url: https://github.com/stelligent/mu-cloudfront/archive/v0.7.zip
 ```
+## Why is us-east-1 required?
 
-
-
+[AWS Cloudfront documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html#https-requirements-aws-region) states that:
+```
+If you want to require HTTPS between viewers and CloudFront, you must change the AWS region to US East (N. Virginia) in the AWS Certificate Manager console before you request or import a certificate.
+```
+Cloudfront is a global service, and AWS Certificate Manager is regional. Therefore, one region had to be choisen to provide the certificates. They chose N. Virginia (us-east-1).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # mu-cloudfront
 Extension to create a CloudFront distribution in front of the ALB for a mu environment.  Additionally, this will create an S3 bucket for static resources.
 
-Sample usage: 
+Sample usage:
 
 ```
-## Specify the id of an ACM cert for CloudFront to use (must be in us-east-1)
+## Specify the id of an ACM cert for CloudFront to use
 parameters:
   mu-loadbalancer-acceptance:
     CloudFrontCert: "0000000-0000-0000-0000-000000000"
 
 extensions:
-- url: https://github.com/stelligent/mu-cloudfront/archive/v0.7.zip
+- url: https://github.com/stelligent/mu-cloudfront/archive/v0.71.zip
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # mu-cloudfront
 Extension to create a CloudFront distribution in front of the ALB for a mu environment.  Additionally, this will create an S3 bucket for static resources.
 
-Sample usage:
+Sample usage: 
 
 ```
-## Specify the id of an ACM cert for CloudFront to use
+## Specify the id of an ACM cert for CloudFront to use (must be in us-east-1)
 parameters:
   mu-loadbalancer-acceptance:
     CloudFrontCert: "0000000-0000-0000-0000-000000000"
 
 extensions:
-- url: https://github.com/stelligent/mu-cloudfront/archive/v0.71.zip
+- url: https://github.com/stelligent/mu-cloudfront/archive/v0.7.zip
 ```
 
 

--- a/elb.yml
+++ b/elb.yml
@@ -74,7 +74,7 @@ Resources:
               QueryString: true
               Cookies:
                 Forward: all
-              Headers: 
+              Headers:
                 - '*'
             MaxTTL: 60
             MinTTL: 0
@@ -145,6 +145,7 @@ Resources:
           Fn::If:
             - HasCloudFrontCert
             - AcmCertificateArn:
+                # us-east-1 is hard-coded for valid reason (see README.md)
                 Fn::Sub: "arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/${CloudFrontCert}"
               MinimumProtocolVersion: TLSv1.2_2018
               SslSupportMethod: sni-only

--- a/mu-extension.yml
+++ b/mu-extension.yml
@@ -1,2 +1,2 @@
 name: mu-cloudfront
-version: '0.71'
+version: '0.7'

--- a/mu-extension.yml
+++ b/mu-extension.yml
@@ -1,2 +1,2 @@
 name: mu-cloudfront
-version: '0.7'
+version: '0.71'


### PR DESCRIPTION
I noticed the README said it would only work in us-east-1. 
The only reference to that region was hardcoded in the template.
This PR changed it to `${AWS::Region}` and bumps the version numbers.